### PR TITLE
Fix output filename check

### DIFF
--- a/project_chameleon/hs2converter.py
+++ b/project_chameleon/hs2converter.py
@@ -18,7 +18,7 @@ def hs2converter(file_name, output_file):
     #Make sure input is a .img file
     if not file_name.endswith('.hs2'):
         raise ValueError("ERROR: bad input. Expected .hs2 file")
-    if not file_name.endswith('.png'):
+    if not output_file.endswith('.png'):
         raise ValueError("ERROR: please make your output file a .png file")
     if not os.path.isfile(file_name):
         raise ValueError("ERROR: Input should be a file. Check if your file exists.")


### PR DESCRIPTION
Fix the output filename check for hs2 conversions. Found during testing of PC deployment for Laue files. With this, works like a charm!!!