### PR TITLE
JSON partial streaming

### DIFF
--- a/api.py
+++ b/api.py
@@ -383,7 +383,9 @@ def common_file_handler_prepare_output(request, data, output_file, media_type = 
         with open(opf, 'rb') as f:
             # binary data as base64 next
             chunk = f.read(CHUNK_SIZE)
-            yield from base64.b64encode(chunk)
+            while len(chunk) > 0:
+                yield from base64.b64encode(chunk)
+                chunk = f.read(CHUNK_SIZE)
         # suffix last
         yield from b'", "file_name": "' + json.dumps(os.path.basename(opf)).encode('utf8') + b'" }';
     rv = StreamingResponse(iterb64encode(output_file), media_type='application/json', background=BackgroundTask(os.unlink, output_file))

--- a/api.py
+++ b/api.py
@@ -386,7 +386,7 @@ def common_file_handler_prepare_output(request, data, output_file, media_type = 
             yield from base64.b64encode(chunk)
         # suffix last
         yield from b'", "file_name": "' + json.dumps(os.path.basename(opf)).encode('utf8') + b'" }';
-    rv = StreamingResponse(iterb64encode(output_file)), media_type='application/json', background=BackgroundTask(os.unlink, output_file))
+    rv = StreamingResponse(iterb64encode(output_file), media_type='application/json', background=BackgroundTask(os.unlink, output_file))
 
     return rv
 


### PR DESCRIPTION
Here is probably a good way to do the JSON partial streaming. It uses a generator interface, implemented here by `iterb64encode`, to return the response JSON one part at a time. `CHUNK_SIZE` controls how much of the file is processed at once, and therefore sets the memory usage. Because 3 input bytes maps to exactly 4 output base64-encoded bytes, for this code to work correctly, `CHUNK_SIZE` must be a multiple of 3. There is probably room for some further optimization (e.g. it is not clear to me that I need to convert bytes to strings before yielding), but this works -- test ed as written and with `CHUNK_SIZE=1` (forcing a great many chunks to be processed individually), in both cases `file_data` in the return JSON, when base64-decoded, is byte-for-byte identical to a `raw` response.

Note for deployers: for a deployment to return large files without running out of space elsewhere in the stack, any proxies/reverse proxies in the web stack need to also stream the response back as it is returned, and not buffer the response.

Closes #23 .