### PR TITLE
Fixup in-package imports to function correctly

### DIFF
--- a/project_chameleon/brukerrawbackground.py
+++ b/project_chameleon/brukerrawbackground.py
@@ -1,4 +1,4 @@
-from brukerrawconverter import brukerrawconverter
+from .brukerrawconverter import brukerrawconverter
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt

--- a/project_chameleon/hs2converter.py
+++ b/project_chameleon/hs2converter.py
@@ -1,4 +1,4 @@
-import numpy as np 
+import numpy as np
 import os
 import matplotlib.pyplot as plt
 from PIL import Image

--- a/project_chameleon/rheed_video_converter.py
+++ b/project_chameleon/rheed_video_converter.py
@@ -1,15 +1,15 @@
 import os
 import glob
-import numpy as np 
+import numpy as np
 from PIL import Image
 import argparse
 import shutil
 from sys import argv, exit
 from time import time, sleep
 from subprocess import Popen, PIPE, DEVNULL
-from rheed_helpers import get_image_dimensions
-from rheed_helpers import rheed_video_frame_parser
-from rheed_helpers import rheed_video_image_parser
+from .rheed_helpers import get_image_dimensions
+from .rheed_helpers import rheed_video_frame_parser
+from .rheed_helpers import rheed_video_image_parser
 import traceback
 
 def rheed_video_converter(input_file, output_file, output_type, keep_images = 0):

--- a/project_chameleon/rheedconverter.py
+++ b/project_chameleon/rheedconverter.py
@@ -1,8 +1,8 @@
 import os
-import numpy as np 
+import numpy as np
 import argparse
 from PIL import Image
-from rheed_helpers import get_image_dimensions
+from .rheed_helpers import get_image_dimensions
 
 
 def rheedconverter(file_name, output_file):


### PR DESCRIPTION
Title says it all. Add "relative to this file" markers for importing items from elsewhere in-package. Required to work without modification in deployment.