### PR TITLE
Fix relative package imports broken by commit 658c37b.

### DIFF
--- a/project_chameleon/brukerrawbackground.py
+++ b/project_chameleon/brukerrawbackground.py
@@ -1,4 +1,4 @@
-from brukerrawconverter import brukerrawconverter
+from .brukerrawconverter import brukerrawconverter
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This commit: https://github.com/paradimdata/project_chameleon/commit/658c37b02e776769fc8fdcbb597e3ac4f64613ab

broke the relative package imports fixed in #29 for the bruker background converter. Fix it here.